### PR TITLE
Implement password hashing with bcrypt (#52)

### DIFF
--- a/agents/github-workflow.md
+++ b/agents/github-workflow.md
@@ -121,8 +121,8 @@ Tickets must progress through kanban lanes in real-time as work happens. Update 
 | Phase | Status | Trigger |
 |-------|--------|---------|
 | Pick up ticket | **In-Progress** | Before writing any code |
-| Code complete, PR opened | **Review** | After pushing branch and creating PR |
-| PR approved / tests green | **QA** | After PR is ready for final validation |
+| Code complete | **QA** | After code is ready for validation |
+| ACs verified and checked off | **Review** | After QA passes, open PR |
 | PR merged to main | **Done** | Only after merge is confirmed |
 
 ### Acceptance Criteria Progression
@@ -155,11 +155,11 @@ gh issue edit NUMBER --body "UPDATED_BODY"
 
 ### After Completing Work
 
-- [ ] Verify all completion criteria are checked
+- [ ] Move issue to **QA**
+- [ ] Verify each completion criterion and check it off on the issue as it passes
 - [ ] Post completion summary comment (use template above)
+- [ ] After all ACs pass QA, create PR referencing the issue number (`Closes #N`)
 - [ ] Move issue to **Review**
-- [ ] Create PR referencing the issue number (`Closes #N`)
-- [ ] After PR approval, move to **QA**
 - [ ] After PR merge, move to **Done**
 
 ### Never Do
@@ -170,6 +170,7 @@ gh issue edit NUMBER --body "UPDATED_BODY"
 - ❌ Consider a task "done" if GitHub isn't updated
 - ❌ Move a ticket to Done before the PR is merged
 - ❌ Check off all acceptance criteria at once — verify and check each individually
+- ❌ Open a PR before QA — ACs must be checked off on the issue first, then the PR is created
 
 ---
 

--- a/backend/src/the_lab/auth/__init__.py
+++ b/backend/src/the_lab/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication and authorization utilities."""

--- a/backend/src/the_lab/auth/password.py
+++ b/backend/src/the_lab/auth/password.py
@@ -1,0 +1,32 @@
+"""Password hashing and verification using bcrypt."""
+
+import bcrypt
+
+_ROUNDS = 12
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password using bcrypt.
+
+    Args:
+        password: The plaintext password to hash.
+
+    Returns:
+        The bcrypt hash string.
+    """
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt(rounds=_ROUNDS)).decode("utf-8")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plaintext password against a bcrypt hash.
+
+    Uses constant-time comparison to prevent timing attacks.
+
+    Args:
+        plain_password: The plaintext password to check.
+        hashed_password: The bcrypt hash to verify against.
+
+    Returns:
+        True if the password matches, False otherwise.
+    """
+    return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))

--- a/backend/tests/test_password.py
+++ b/backend/tests/test_password.py
@@ -1,0 +1,73 @@
+"""Tests for password hashing and verification."""
+
+import pytest
+
+from the_lab.auth.password import hash_password, verify_password
+
+
+class TestHashPassword:
+    """Tests for hash_password()."""
+
+    def test_returns_bcrypt_hash(self) -> None:
+        result = hash_password("mypassword")
+        assert result.startswith("$2b$")
+
+    def test_uses_cost_factor_12(self) -> None:
+        result = hash_password("mypassword")
+        # bcrypt format: $2b$<rounds>$<salt+hash>
+        assert result.startswith("$2b$12$")
+
+    def test_different_calls_produce_different_hashes(self) -> None:
+        hash1 = hash_password("same_password")
+        hash2 = hash_password("same_password")
+        assert hash1 != hash2
+
+    def test_empty_password(self) -> None:
+        result = hash_password("")
+        assert result.startswith("$2b$12$")
+
+
+class TestVerifyPassword:
+    """Tests for verify_password()."""
+
+    def test_correct_password_returns_true(self) -> None:
+        hashed = hash_password("correcthorse")
+        assert verify_password("correcthorse", hashed) is True
+
+    def test_wrong_password_returns_false(self) -> None:
+        hashed = hash_password("correcthorse")
+        assert verify_password("wrongpassword", hashed) is False
+
+    def test_empty_password_matches_empty_hash(self) -> None:
+        hashed = hash_password("")
+        assert verify_password("", hashed) is True
+
+    def test_empty_password_does_not_match_nonempty(self) -> None:
+        hashed = hash_password("notempty")
+        assert verify_password("", hashed) is False
+
+    def test_case_sensitive(self) -> None:
+        hashed = hash_password("Password")
+        assert verify_password("password", hashed) is False
+        assert verify_password("PASSWORD", hashed) is False
+        assert verify_password("Password", hashed) is True
+
+    def test_unicode_password(self) -> None:
+        hashed = hash_password("pässwörd123")
+        assert verify_password("pässwörd123", hashed) is True
+        assert verify_password("passwörd123", hashed) is False
+
+    def test_long_password_raises(self) -> None:
+        # bcrypt 5.x enforces the 72-byte limit
+        long_pw = "a" * 100
+        with pytest.raises(ValueError, match="72 bytes"):
+            hash_password(long_pw)
+
+    def test_max_length_password(self) -> None:
+        pw_72 = "a" * 72
+        hashed = hash_password(pw_72)
+        assert verify_password(pw_72, hashed) is True
+
+    def test_invalid_hash_raises(self) -> None:
+        with pytest.raises(ValueError):
+            verify_password("password", "not-a-valid-hash")


### PR DESCRIPTION
## Summary
- Add `hash_password()` and `verify_password()` in `backend/src/the_lab/auth/password.py`
- Uses `bcrypt` directly (passlib is incompatible with bcrypt 5.x on Python 3.13)
- Cost factor 12, constant-time comparison via `bcrypt.checkpw()`
- 13 tests covering correctness, edge cases (empty, unicode, case sensitivity, 72-byte limit, invalid hashes)
- Updates `agents/github-workflow.md` with PR ordering rule (QA before PR)

## Test plan
- [x] `hash_password()` returns `$2b$12$` prefixed hashes
- [x] `verify_password()` correctly matches/rejects passwords
- [x] Edge cases: empty, unicode, case sensitivity, max length, invalid hash
- [x] Ruff lint clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)