### PR TITLE
Create JWT token generation and validation (#53)

### DIFF
--- a/agents/github-workflow.md
+++ b/agents/github-workflow.md
@@ -27,9 +27,9 @@ This document provides explicit instructions for Claude Code to interact with Gi
 | Backlog | Initial creation; not yet ready for work |
 | Refined | Requirements clear; ready to be picked up |
 | In-Progress | Actively being worked on |
-| Review | Code complete; awaiting review |
-| QA | Review passed; awaiting QA validation |
-| Done | All acceptance criteria verified |
+| Review | Code complete; code_reviewer and security_reviewer agents review the work |
+| QA | Reviews passed; ACs verified and checked off, then PR opened |
+| Done | PR merged to main |
 | Deployed | Released to production |
 
 ---
@@ -74,11 +74,11 @@ Update the issue body to check off completed items:
 gh issue edit NUMBER --repo rcw0086/the_lab --body "UPDATED_BODY_WITH_CHECKED_ITEMS"
 ```
 
-### When Work is Complete
+### When Code is Complete
 
-1. Move to Review status
+1. Move to **Review** status
 2. Post completion summary as comment
-3. Link any PRs
+3. The **code_reviewer** and **security_reviewer** agents review the work
 
 ```bash
 # Move to Review
@@ -100,16 +100,23 @@ gh issue comment NUMBER --repo rcw0086/the_lab --body "$(cat <<'EOF'
 **Risks:**
 - [Known risks or "None identified"]
 
-**Definition of Done status:**
-- [x] Scope documented
-- [x] Tests exist
-- [x] Docs updated
-- etc.
-
 **Next steps:**
-- Move to QA for validation
+- Move to Review for code_reviewer and security_reviewer
 EOF
 )"
+```
+
+### When Reviews Pass
+
+1. Move to **QA** status
+2. Verify each acceptance criterion and check it off on the issue
+3. After all ACs pass, open the PR
+
+```bash
+# Move to QA
+gh project item-edit --project-id PVT_kwHOALRmDc4BM53F --id ITEM_ID --field-id PVTSSF_lAHOALRmDc4BM53Fzg8DYxY --single-select-option-id QA_OPTION_ID
+
+# Verify and check off ACs one by one, then open PR
 ```
 
 ---
@@ -121,8 +128,8 @@ Tickets must progress through kanban lanes in real-time as work happens. Update 
 | Phase | Status | Trigger |
 |-------|--------|---------|
 | Pick up ticket | **In-Progress** | Before writing any code |
-| Code complete | **QA** | After code is ready for validation |
-| ACs verified and checked off | **Review** | After QA passes, open PR |
+| Code complete | **Review** | code_reviewer and security_reviewer agents review |
+| Reviews pass | **QA** | Verify ACs, check them off, then open PR |
 | PR merged to main | **Done** | Only after merge is confirmed |
 
 ### Acceptance Criteria Progression
@@ -153,13 +160,14 @@ gh issue edit NUMBER --body "UPDATED_BODY"
 - [ ] Post progress comments for significant milestones
 - [ ] Link commits/PRs to the issue
 
-### After Completing Work
+### After Completing Code
 
-- [ ] Move issue to **QA**
-- [ ] Verify each completion criterion and check it off on the issue as it passes
 - [ ] Post completion summary comment (use template above)
-- [ ] After all ACs pass QA, create PR referencing the issue number (`Closes #N`)
 - [ ] Move issue to **Review**
+- [ ] code_reviewer and security_reviewer agents review the work
+- [ ] After reviews pass, move issue to **QA**
+- [ ] Verify each acceptance criterion and check it off on the issue as it passes
+- [ ] After all ACs pass, create PR referencing the issue number (`Closes #N`)
 - [ ] After PR merge, move to **Done**
 
 ### Never Do
@@ -170,7 +178,8 @@ gh issue edit NUMBER --body "UPDATED_BODY"
 - ❌ Consider a task "done" if GitHub isn't updated
 - ❌ Move a ticket to Done before the PR is merged
 - ❌ Check off all acceptance criteria at once — verify and check each individually
-- ❌ Open a PR before QA — ACs must be checked off on the issue first, then the PR is created
+- ❌ Open a PR before QA — ACs must be checked off on the issue during QA, then the PR is created
+- ❌ Skip Review — code_reviewer and security_reviewer agents must review before moving to QA
 
 ---
 
@@ -225,10 +234,13 @@ gh issue edit 8 --repo rcw0086/the_lab --body "UPDATED_BODY"
 # Post completion summary
 gh issue comment 8 --repo rcw0086/the_lab --body "## Completion Summary ..."
 
-# Move to Review
+# Move to Review — code_reviewer and security_reviewer agents review
 gh project item-edit --project-id PVT_kwHOALRmDc4BM53F --id PVTI_xxx --field-id PVTSSF_lAHOALRmDc4BM53Fzg8DYxY --single-select-option-id 0a9b80ca
 
-# After QA passes, move to Done
+# After reviews pass, move to QA — verify ACs, check them off, open PR
+gh project item-edit --project-id PVT_kwHOALRmDc4BM53F --id PVTI_xxx --field-id PVTSSF_lAHOALRmDc4BM53Fzg8DYxY --single-select-option-id ca5048d6
+
+# After PR merge, move to Done
 gh project item-edit --project-id PVT_kwHOALRmDc4BM53F --id PVTI_xxx --field-id PVTSSF_lAHOALRmDc4BM53Fzg8DYxY --single-select-option-id f2abef06
 ```
 

--- a/backend/src/the_lab/auth/jwt.py
+++ b/backend/src/the_lab/auth/jwt.py
@@ -1,0 +1,93 @@
+"""JWT token generation and validation."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from jose import JWTError, jwt
+
+from the_lab.config import get_settings
+from the_lab.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class TokenError(Exception):
+    """Raised when a token is invalid or expired."""
+
+
+def create_access_token(user_id: int, username: str, role: str | None = None) -> str:
+    """Create a short-lived JWT access token.
+
+    Args:
+        user_id: The user's database ID.
+        username: The user's username.
+        role: The user's role (e.g. "admin", "athlete").
+
+    Returns:
+        Encoded JWT string.
+    """
+    settings = get_settings()
+    now = datetime.now(UTC)
+    claims: dict[str, Any] = {
+        "sub": str(user_id),
+        "username": username,
+        "role": role,
+        "type": "access",
+        "iat": now,
+        "exp": now + timedelta(minutes=settings.jwt_access_token_expire_minutes),
+    }
+    result: str = jwt.encode(claims, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    return result
+
+
+def create_refresh_token(user_id: int) -> str:
+    """Create a long-lived JWT refresh token.
+
+    Args:
+        user_id: The user's database ID.
+
+    Returns:
+        Encoded JWT string.
+    """
+    settings = get_settings()
+    now = datetime.now(UTC)
+    claims: dict[str, Any] = {
+        "sub": str(user_id),
+        "type": "refresh",
+        "iat": now,
+        "exp": now + timedelta(days=settings.jwt_refresh_token_expire_days),
+    }
+    result: str = jwt.encode(claims, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    return result
+
+
+def verify_token(token: str, expected_type: Literal["access", "refresh"] = "access") -> dict[str, Any]:
+    """Decode and validate a JWT token.
+
+    Args:
+        token: The encoded JWT string.
+        expected_type: Expected token type ("access" or "refresh").
+
+    Returns:
+        The decoded claims dictionary.
+
+    Raises:
+        TokenError: If the token is invalid, expired, or has the wrong type.
+    """
+    settings = get_settings()
+    try:
+        payload = jwt.decode(
+            token,
+            settings.jwt_secret_key,
+            algorithms=[settings.jwt_algorithm],
+        )
+    except JWTError as exc:
+        logger.warning("token_validation_failed", error=str(exc))
+        raise TokenError("Invalid or expired token") from exc
+
+    if payload.get("type") != expected_type:
+        logger.warning("token_type_mismatch", expected=expected_type, got=payload.get("type"))
+        raise TokenError("Invalid token type")
+
+    result: dict[str, Any] = payload
+    return result

--- a/backend/src/the_lab/config.py
+++ b/backend/src/the_lab/config.py
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
 
     # JWT Authentication
     jwt_secret_key: str  # REQUIRED - must be set via JWT_SECRET_KEY environment variable
-    jwt_algorithm: str = "HS256"
+    jwt_algorithm: Literal["HS256", "HS384", "HS512"] = "HS256"
     jwt_access_token_expire_minutes: int = 30
     jwt_refresh_token_expire_days: int = 7
 

--- a/backend/tests/test_jwt.py
+++ b/backend/tests/test_jwt.py
@@ -1,0 +1,157 @@
+"""Tests for JWT token generation and validation."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from jose import jwt
+
+from the_lab.auth.jwt import (
+    TokenError,
+    create_access_token,
+    create_refresh_token,
+    verify_token,
+)
+from the_lab.config import get_settings
+
+
+class TestCreateAccessToken:
+    """Tests for create_access_token()."""
+
+    def test_returns_string(self) -> None:
+        token = create_access_token(user_id=1, username="alice")
+        assert isinstance(token, str)
+
+    def test_contains_expected_claims(self) -> None:
+        settings = get_settings()
+        token = create_access_token(user_id=42, username="alice", role="athlete")
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+
+        assert payload["sub"] == "42"
+        assert payload["username"] == "alice"
+        assert payload["role"] == "athlete"
+        assert payload["type"] == "access"
+        assert "exp" in payload
+        assert "iat" in payload
+
+    def test_sub_is_string(self) -> None:
+        settings = get_settings()
+        token = create_access_token(user_id=7, username="bob")
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        assert payload["sub"] == "7"
+
+    def test_role_defaults_to_none(self) -> None:
+        settings = get_settings()
+        token = create_access_token(user_id=1, username="alice")
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        assert payload["role"] is None
+
+    def test_expiration_is_set(self) -> None:
+        settings = get_settings()
+        before = datetime.now(UTC)
+        token = create_access_token(user_id=1, username="alice")
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+
+        exp = datetime.fromtimestamp(payload["exp"], tz=UTC)
+        expected = before + timedelta(minutes=settings.jwt_access_token_expire_minutes)
+        # Allow 5 seconds of drift
+        assert abs((exp - expected).total_seconds()) < 5
+
+
+class TestCreateRefreshToken:
+    """Tests for create_refresh_token()."""
+
+    def test_returns_string(self) -> None:
+        token = create_refresh_token(user_id=1)
+        assert isinstance(token, str)
+
+    def test_contains_expected_claims(self) -> None:
+        settings = get_settings()
+        token = create_refresh_token(user_id=42)
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+
+        assert payload["sub"] == "42"
+        assert payload["type"] == "refresh"
+        assert "exp" in payload
+        assert "iat" in payload
+        assert "username" not in payload
+        assert "role" not in payload
+
+    def test_expiration_is_longer_than_access(self) -> None:
+        settings = get_settings()
+        access = create_access_token(user_id=1, username="alice")
+        refresh = create_refresh_token(user_id=1)
+
+        access_payload = jwt.decode(access, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        refresh_payload = jwt.decode(refresh, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+
+        assert refresh_payload["exp"] > access_payload["exp"]
+
+
+class TestVerifyToken:
+    """Tests for verify_token()."""
+
+    def test_valid_access_token(self) -> None:
+        token = create_access_token(user_id=1, username="alice", role="admin")
+        payload = verify_token(token, expected_type="access")
+
+        assert payload["sub"] == "1"
+        assert payload["username"] == "alice"
+        assert payload["role"] == "admin"
+
+    def test_valid_refresh_token(self) -> None:
+        token = create_refresh_token(user_id=1)
+        payload = verify_token(token, expected_type="refresh")
+
+        assert payload["sub"] == "1"
+        assert payload["type"] == "refresh"
+
+    def test_defaults_to_access_type(self) -> None:
+        token = create_access_token(user_id=1, username="alice")
+        payload = verify_token(token)
+        assert payload["type"] == "access"
+
+    def test_wrong_type_raises(self) -> None:
+        token = create_access_token(user_id=1, username="alice")
+        with pytest.raises(TokenError, match="Invalid token type"):
+            verify_token(token, expected_type="refresh")
+
+    def test_refresh_as_access_raises(self) -> None:
+        token = create_refresh_token(user_id=1)
+        with pytest.raises(TokenError, match="Invalid token type"):
+            verify_token(token, expected_type="access")
+
+    def test_expired_token_raises(self) -> None:
+        settings = get_settings()
+        claims = {
+            "sub": "1",
+            "username": "alice",
+            "type": "access",
+            "iat": datetime.now(UTC) - timedelta(hours=2),
+            "exp": datetime.now(UTC) - timedelta(hours=1),
+        }
+        token = jwt.encode(claims, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+        with pytest.raises(TokenError, match="Invalid or expired token"):
+            verify_token(token)
+
+    def test_invalid_signature_raises(self) -> None:
+        settings = get_settings()
+        claims = {
+            "sub": "1",
+            "username": "alice",
+            "type": "access",
+            "iat": datetime.now(UTC),
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        }
+        token = jwt.encode(claims, "wrong-secret-key", algorithm=settings.jwt_algorithm)
+
+        with pytest.raises(TokenError, match="Invalid or expired token"):
+            verify_token(token)
+
+    def test_malformed_token_raises(self) -> None:
+        with pytest.raises(TokenError, match="Invalid or expired token"):
+            verify_token("not.a.valid.token")
+
+    def test_empty_token_raises(self) -> None:
+        with pytest.raises(TokenError, match="Invalid or expired token"):
+            verify_token("")


### PR DESCRIPTION
## Summary
- Add `create_access_token()`, `create_refresh_token()`, and `verify_token()` in `backend/src/the_lab/auth/jwt.py`
- Custom `TokenError` exception with generic error messages (no internal detail leakage)
- Token type enforcement prevents refresh/access token confusion
- Constrain `jwt_algorithm` config to `HS256|HS384|HS512` (prevents algorithm substitution)
- 17 JWT tests + 13 password tests all passing
- Updates `agents/github-workflow.md` with corrected lane order (Review → QA)

## Review findings addressed
- **Security**: Generic error messages — internal details logged via structlog, not exposed to callers
- **Security**: `jwt_algorithm` constrained to HMAC family via `Literal` type
- **Code**: `expected_type` parameter constrained with `Literal["access", "refresh"]`

## Test plan
- [x] `create_access_token()` produces valid JWT with correct claims
- [x] `create_refresh_token()` produces valid JWT with longer expiry
- [x] `verify_token()` accepts valid tokens and rejects expired/invalid/wrong-type
- [x] Generic error messages don't leak internals
- [x] Ruff lint clean
- [x] 30/30 auth tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)