### PR TITLE
Build registration endpoint (#54)

### DIFF
--- a/backend/src/the_lab/auth/router.py
+++ b/backend/src/the_lab/auth/router.py
@@ -1,0 +1,43 @@
+"""Authentication API routes."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from the_lab.auth.password import hash_password
+from the_lab.db.models.core import User
+from the_lab.db.session import get_db
+from the_lab.schemas.auth import RegisterRequest, UserRead
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+def register(payload: RegisterRequest, db: Session = Depends(get_db)) -> User:  # noqa: B008
+    """Register a new user.
+
+    Creates a user with a bcrypt-hashed password. Returns the created user
+    without the password hash.
+    """
+    existing = db.query(User).filter(User.username == payload.username).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already taken",
+        )
+
+    user = User(
+        username=payload.username,
+        password_hash=hash_password(payload.password),
+    )
+    db.add(user)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already taken",
+        ) from None
+    db.refresh(user)
+    return user

--- a/backend/src/the_lab/db/models/core.py
+++ b/backend/src/the_lab/db/models/core.py
@@ -60,6 +60,11 @@ class User(Base):
         nullable=False,
         doc="Unique username for authentication",
     )
+    password_hash: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        doc="Bcrypt password hash",
+    )
     role: Mapped[str | None] = mapped_column(
         String(64),
         nullable=True,

--- a/backend/src/the_lab/main.py
+++ b/backend/src/the_lab/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
+from the_lab.auth.router import router as auth_router
 from the_lab.config import get_settings
 from the_lab.db.session import engine
 from the_lab.logging import get_logger, setup_logging
@@ -53,6 +54,8 @@ def create_app() -> FastAPI:
         allow_methods=settings.cors_allow_methods,
         allow_headers=settings.cors_allow_headers,
     )
+
+    app.include_router(auth_router)
 
     @app.get("/")
     async def root() -> dict[str, str]:

--- a/backend/src/the_lab/schemas/auth.py
+++ b/backend/src/the_lab/schemas/auth.py
@@ -1,0 +1,22 @@
+"""Authentication request/response schemas."""
+
+from datetime import datetime
+
+from pydantic import Field
+
+from the_lab.schemas.base import CreateSchema, ReadSchema
+
+
+class RegisterRequest(CreateSchema):
+    """Schema for POST /auth/register."""
+
+    username: str = Field(min_length=3, max_length=128)
+    password: str = Field(min_length=8, max_length=72)
+
+
+class UserRead(ReadSchema):
+    """Schema for user responses (excludes password_hash)."""
+
+    username: str
+    role: str | None = None
+    created_at: datetime

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -165,7 +165,7 @@ def db_session(setup_test_database: None) -> Generator[Session, None, None]:
 
     Usage:
         def test_something(db_session: Session):
-            user = User(username="test")
+            user = User(username="test", password_hash="$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte")
             db_session.add(user)
             db_session.commit()
             # Changes are rolled back after test
@@ -221,7 +221,7 @@ def test_user(db_session: Session) -> Any:
     """
     from the_lab.db.models.core import User
 
-    user = User(username="test_user")
+    user = User(username="test_user", password_hash="$2b$12$fakehashfortest000000000000000000000000000000000000000")
     db_session.add(user)
     db_session.commit()
     return user

--- a/backend/tests/fixtures/factories.py
+++ b/backend/tests/fixtures/factories.py
@@ -38,10 +38,14 @@ from the_lab.db.models.sets import (
 # ============================================================
 
 
+_TEST_PASSWORD_HASH = "$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte"
+
+
 def create_user(
     session: Session,
     username: str | None = None,
     role: str | None = None,
+    password_hash: str | None = None,
     flush: bool = True,
     **kwargs: Any,
 ) -> User:
@@ -51,6 +55,7 @@ def create_user(
         session: Database session
         username: User's username (default: test_user_<timestamp>)
         role: User's role (optional)
+        password_hash: Bcrypt hash (default: test placeholder)
         flush: Whether to flush immediately (default: True)
         **kwargs: Additional fields to override
 
@@ -60,7 +65,12 @@ def create_user(
     if username is None:
         username = f"test_user_{datetime.now().timestamp()}"
 
-    user = User(username=username, role=role, **kwargs)
+    user = User(
+        username=username,
+        role=role,
+        password_hash=password_hash or _TEST_PASSWORD_HASH,
+        **kwargs,
+    )
     session.add(user)
     if flush:
         session.flush()  # Flush to get ID without committing

--- a/backend/tests/test_core_models.py
+++ b/backend/tests/test_core_models.py
@@ -22,7 +22,7 @@ class TestUser:
 
     def test_create_user(self, db_session: Session) -> None:
         """Test creating a user with required fields."""
-        user = User(username="test_user")
+        user = User(username="test_user", password_hash="$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte")
         db_session.add(user)
         db_session.commit()
 
@@ -33,18 +33,18 @@ class TestUser:
 
     def test_username_unique_constraint(self, db_session: Session) -> None:
         """Test that username must be unique."""
-        user1 = User(username="duplicate")
+        user1 = User(username="duplicate", password_hash="$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte")
         db_session.add(user1)
         db_session.commit()
 
-        user2 = User(username="duplicate")
+        user2 = User(username="duplicate", password_hash="$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte")
         db_session.add(user2)
         with pytest.raises(IntegrityError):
             db_session.commit()
 
     def test_user_with_role(self, db_session: Session) -> None:
         """Test creating user with role."""
-        user = User(username="admin_user", role="admin")
+        user = User(username="admin_user", password_hash="$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte", role="admin")
         db_session.add(user)
         db_session.commit()
 
@@ -281,7 +281,7 @@ class TestRelationships:
 @pytest.fixture
 def test_user(db_session: Session) -> User:
     """Create a test user."""
-    user = User(username="test_user")
+    user = User(username="test_user", password_hash="$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte")
     db_session.add(user)
     db_session.commit()
     return user

--- a/backend/tests/test_register.py
+++ b/backend/tests/test_register.py
@@ -1,0 +1,118 @@
+"""Integration tests for POST /auth/register."""
+
+import os
+
+os.environ["JWT_SECRET_KEY"] = os.environ.get(
+    "JWT_SECRET_KEY", "test-jwt-secret-key-at-least-32-characters-long-for-testing"
+)
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from the_lab.db.models.core import User
+from the_lab.db.session import get_db
+from the_lab.main import create_app
+
+
+def _make_client(db_session: Session) -> TestClient:
+    """Create a test client with the DB session overridden."""
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: db_session
+    return TestClient(app)
+
+
+class TestRegisterEndpoint:
+    """Tests for POST /auth/register."""
+
+    def test_register_success(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/register",
+            json={"username": "newuser", "password": "securepass123"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["username"] == "newuser"
+        assert data["role"] is None
+        assert "id" in data
+        assert "created_at" in data
+        assert "password" not in data
+        assert "password_hash" not in data
+
+    def test_register_stores_hashed_password(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        client.post(
+            "/auth/register",
+            json={"username": "hashcheck", "password": "mypassword"},
+        )
+        user = db_session.query(User).filter(User.username == "hashcheck").first()
+        assert user is not None
+        assert user.password_hash.startswith("$2b$12$")
+        assert user.password_hash != "mypassword"
+
+    def test_register_duplicate_username_returns_409(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        client.post(
+            "/auth/register",
+            json={"username": "dupeuser", "password": "password123"},
+        )
+        response = client.post(
+            "/auth/register",
+            json={"username": "dupeuser", "password": "otherpass123"},
+        )
+        assert response.status_code == 409
+        assert "already taken" in response.json()["detail"]
+
+    def test_register_username_too_short(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/register",
+            json={"username": "ab", "password": "password123"},
+        )
+        assert response.status_code == 422
+
+    def test_register_password_too_short(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/register",
+            json={"username": "validuser", "password": "short"},
+        )
+        assert response.status_code == 422
+
+    def test_register_password_too_long(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/register",
+            json={"username": "validuser", "password": "a" * 73},
+        )
+        assert response.status_code == 422
+
+    def test_register_missing_username(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/register",
+            json={"password": "password123"},
+        )
+        assert response.status_code == 422
+
+    def test_register_missing_password(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/register",
+            json={"username": "validuser"},
+        )
+        assert response.status_code == 422
+
+    def test_register_empty_body(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post("/auth/register", json={})
+        assert response.status_code == 422
+
+    def test_register_strips_whitespace(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/register",
+            json={"username": "  spaceduser  ", "password": "password123"},
+        )
+        assert response.status_code == 201
+        assert response.json()["username"] == "spaceduser"

--- a/backend/tests/test_session_models.py
+++ b/backend/tests/test_session_models.py
@@ -267,7 +267,7 @@ class TestRelationships:
 @pytest.fixture
 def test_user(db_session: DBSession) -> User:
     """Create a test user."""
-    user = User(username="test_user")
+    user = User(username="test_user", password_hash="$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte")
     db_session.add(user)
     db_session.commit()
     return user

--- a/backend/tests/test_sets_models.py
+++ b/backend/tests/test_sets_models.py
@@ -38,7 +38,7 @@ from the_lab.db.enums import (
 @pytest.fixture
 def test_user(db_session: DBSession) -> User:
     """Create a test user."""
-    user = User(username="test_user")
+    user = User(username="test_user", password_hash="$2b$12$testhashtesthashtesthashtesthashtesthashtesthashte")
     db_session.add(user)
     db_session.commit()
     return user


### PR DESCRIPTION
## Summary
- Add `POST /auth/register` endpoint with bcrypt password hashing
- Add `password_hash` column to User model (NOT NULL)
- `RegisterRequest` schema with validation (username 3-128 chars, password 8-72 chars)
- `UserRead` response schema excludes `password_hash`
- Handles duplicate username via app-level check + `IntegrityError` fallback for race conditions
- 10 integration tests covering success, duplicates, validation errors, whitespace stripping
- Updated all existing test fixtures to include `password_hash`
- 230/230 tests passing

## Review findings addressed
- **Security**: `IntegrityError` catch prevents 500 on concurrent duplicate registration
- **Security**: Password never logged (middleware only logs method/path/status)
- **Security**: Response schema explicitly excludes sensitive fields

## Test plan
- [x] Registration creates user with bcrypt hash
- [x] Duplicate username returns 409
- [x] Invalid input (short username/password, missing fields) returns 422
- [x] Whitespace stripped from username
- [x] Full test suite passes (230 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)