### PR TITLE
Docs/agent system refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+Reference agents/agents.md and all subagent .md files with every session in this project. All agents follow all relevant instructions in those files at all times and never complete a task before ensure the workflow defined in those files is STRICTLY FOLLOWED.
+
+Use worktrees for subagents.

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -30,6 +30,8 @@ Specialist agents do **not** self-authorize downstream starts.
 
 Enforce: Planner readiness → AR → DE → DO → BE → FE → Review → Security → QA → Done/Deployed
 
+When asked to perform work defined in GitHub tasks, unless explicitly instructed to do otherwise, move all relevant GitHub issues through all relevant stages of work as defined above in this section, using the appropriate subagents, without asking to proceed to the next task.
+
 ### 2) Stage gate enforcement
 
 - Verify Entry Criteria for the next lane


### PR DESCRIPTION
Added a CLAUDE.md file to the project root, directing Claude Code to reference agents/agents.md in all sessions. Added additional instructions for the orchestrator when implementing tasks in GitHub issues.