### PR TITLE
Add POST /auth/login endpoint (#55)

### DIFF
--- a/backend/src/the_lab/auth/router.py
+++ b/backend/src/the_lab/auth/router.py
@@ -4,10 +4,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from the_lab.auth.password import hash_password
+from the_lab.auth.jwt import create_access_token, create_refresh_token
+from the_lab.auth.password import hash_password, verify_password
 from the_lab.db.models.core import User
 from the_lab.db.session import get_db
-from the_lab.schemas.auth import RegisterRequest, UserRead
+from the_lab.schemas.auth import LoginRequest, RegisterRequest, TokenResponse, UserRead
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -41,3 +42,29 @@ def register(payload: RegisterRequest, db: Session = Depends(get_db)) -> User:  
         ) from None
     db.refresh(user)
     return user
+
+
+@router.post("/login", response_model=TokenResponse)
+def login(payload: LoginRequest, db: Session = Depends(get_db)) -> TokenResponse:  # noqa: B008
+    """Authenticate a user and return JWT tokens.
+
+    Validates username and password, returning access and refresh tokens
+    on success. Returns a generic 401 error for invalid credentials to
+    prevent user enumeration.
+    """
+    user = db.query(User).filter(User.username == payload.username).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+
+    if not verify_password(payload.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+
+    access_token = create_access_token(user.id, user.username, user.role)
+    refresh_token = create_refresh_token(user.id)
+    return TokenResponse(access_token=access_token, refresh_token=refresh_token)

--- a/backend/src/the_lab/schemas/auth.py
+++ b/backend/src/the_lab/schemas/auth.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from the_lab.schemas.base import CreateSchema, ReadSchema
 
@@ -12,6 +12,21 @@ class RegisterRequest(CreateSchema):
 
     username: str = Field(min_length=3, max_length=128)
     password: str = Field(min_length=8, max_length=72)
+
+
+class LoginRequest(CreateSchema):
+    """Schema for POST /auth/login."""
+
+    username: str = Field(min_length=1, max_length=128)
+    password: str = Field(min_length=1, max_length=72)
+
+
+class TokenResponse(BaseModel):
+    """Schema for token responses."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
 
 
 class UserRead(ReadSchema):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,15 @@ This module provides common fixtures used across test modules, including:
 """
 
 import os
+
+# Override settings to use test database BEFORE importing anything from the_lab
+# (the_lab.db.__init__ triggers get_settings() at import time via session.py)
+os.environ["POSTGRES_DB"] = "the_lab_test"
+# Set JWT secret key for tests (required field as of security fix)
+os.environ["JWT_SECRET_KEY"] = os.environ.get(
+    "JWT_SECRET_KEY", "test-jwt-secret-key-at-least-32-characters-long-for-testing"
+)
+
 from collections.abc import Generator
 from typing import Any
 
@@ -17,11 +26,6 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from the_lab.db.base import Base
-
-# Override settings to use test database BEFORE importing settings
-os.environ["POSTGRES_DB"] = "the_lab_test"
-# Set JWT secret key for tests (required field as of security fix)
-os.environ["JWT_SECRET_KEY"] = "test-jwt-secret-key-at-least-32-characters-long-for-testing"
 
 from tests.test_settings import get_test_settings
 

--- a/backend/tests/test_login.py
+++ b/backend/tests/test_login.py
@@ -1,0 +1,105 @@
+"""Integration tests for POST /auth/login."""
+
+import os
+
+os.environ["JWT_SECRET_KEY"] = os.environ.get(
+    "JWT_SECRET_KEY", "test-jwt-secret-key-at-least-32-characters-long-for-testing"
+)
+
+from jose import jwt
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from the_lab.db.session import get_db
+from the_lab.main import create_app
+
+
+def _make_client(db_session: Session) -> TestClient:
+    """Create a test client with the DB session overridden."""
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: db_session
+    return TestClient(app)
+
+
+def _register_user(client: TestClient, username: str = "loginuser", password: str = "securepass123") -> None:
+    """Register a user via the API so they have a real bcrypt hash."""
+    response = client.post(
+        "/auth/register",
+        json={"username": username, "password": password},
+    )
+    assert response.status_code == 201
+
+
+class TestLoginEndpoint:
+    """Tests for POST /auth/login."""
+
+    def test_login_success(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        _register_user(client)
+        response = client.post(
+            "/auth/login",
+            json={"username": "loginuser", "password": "securepass123"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert "refresh_token" in data
+        assert data["token_type"] == "bearer"
+
+    def test_login_invalid_username(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        _register_user(client)
+        response = client.post(
+            "/auth/login",
+            json={"username": "nonexistent", "password": "securepass123"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid credentials"
+
+    def test_login_invalid_password(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        _register_user(client)
+        response = client.post(
+            "/auth/login",
+            json={"username": "loginuser", "password": "wrongpassword"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid credentials"
+
+    def test_login_missing_username(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/login",
+            json={"password": "securepass123"},
+        )
+        assert response.status_code == 422
+
+    def test_login_missing_password(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post(
+            "/auth/login",
+            json={"username": "loginuser"},
+        )
+        assert response.status_code == 422
+
+    def test_login_empty_body(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        response = client.post("/auth/login", json={})
+        assert response.status_code == 422
+
+    def test_login_returns_valid_jwt(self, db_session: Session) -> None:
+        client = _make_client(db_session)
+        _register_user(client)
+        response = client.post(
+            "/auth/login",
+            json={"username": "loginuser", "password": "securepass123"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        secret = os.environ["JWT_SECRET_KEY"]
+        decoded = jwt.decode(data["access_token"], secret, algorithms=["HS256"])
+        assert decoded["username"] == "loginuser"
+        assert decoded["type"] == "access"
+        assert "sub" in decoded
+        assert "exp" in decoded


### PR DESCRIPTION
## Summary
- Adds `POST /auth/login` endpoint that validates credentials and returns JWT access + refresh tokens
- Adds `LoginRequest` and `TokenResponse` schemas
- Returns generic 401 for invalid username or password (prevents user enumeration per ADR-004)
- Fixes env var ordering in test conftest to ensure settings load before `the_lab` imports

## Changes
- `backend/src/the_lab/auth/router.py` — new login endpoint
- `backend/src/the_lab/schemas/auth.py` — `LoginRequest`, `TokenResponse` schemas
- `backend/tests/test_login.py` — 7 integration tests (new file)
- `backend/tests/conftest.py` — env var ordering fix

## Test plan
- [x] Login with valid credentials returns 200 with access_token, refresh_token, token_type=bearer
- [x] Invalid username returns 401 with generic "Invalid credentials"
- [x] Invalid password returns 401 with generic "Invalid credentials"
- [x] Missing username/password returns 422
- [x] Empty body returns 422
- [x] Returned access_token decodes to valid JWT with correct claims
- [x] All existing register tests still pass (no regressions)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)