### PR TITLE
Add get_current_user() auth dependency (#56)

### DIFF
--- a/backend/src/the_lab/auth/dependencies.py
+++ b/backend/src/the_lab/auth/dependencies.py
@@ -1,0 +1,57 @@
+"""FastAPI dependencies for authentication."""
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from the_lab.auth.jwt import TokenError, verify_token
+from the_lab.db.models.core import User
+from the_lab.db.session import get_db
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    db: Session = Depends(get_db),
+) -> User:
+    """Extract and validate JWT from Authorization header, return the User.
+
+    Raises 401 if:
+    - No Authorization header / not Bearer scheme
+    - Token is invalid or expired
+    - User referenced by token no longer exists
+    """
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        payload = verify_token(credentials.credentials, expected_type="access")
+    except TokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from None
+
+    user_id = payload.get("sub")
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token claims",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user = db.query(User).filter(User.id == int(user_id)).first()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return user

--- a/backend/src/the_lab/auth/router.py
+++ b/backend/src/the_lab/auth/router.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from the_lab.auth.dependencies import get_current_user
 from the_lab.auth.jwt import create_access_token, create_refresh_token
 from the_lab.auth.password import hash_password, verify_password
 from the_lab.db.models.core import User
@@ -68,3 +69,9 @@ def login(payload: LoginRequest, db: Session = Depends(get_db)) -> TokenResponse
     access_token = create_access_token(user.id, user.username, user.role)
     refresh_token = create_refresh_token(user.id)
     return TokenResponse(access_token=access_token, refresh_token=refresh_token)
+
+
+@router.get("/me", response_model=UserRead)
+def get_me(current_user: User = Depends(get_current_user)) -> User:
+    """Return the currently authenticated user."""
+    return current_user

--- a/backend/tests/test_auth_dependency.py
+++ b/backend/tests/test_auth_dependency.py
@@ -1,0 +1,121 @@
+"""Integration tests for GET /auth/me (auth dependency)."""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+os.environ["JWT_SECRET_KEY"] = os.environ.get(
+    "JWT_SECRET_KEY", "test-jwt-secret-key-at-least-32-characters-long-for-testing"
+)
+
+from jose import jwt
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from the_lab.db.session import get_db
+from the_lab.main import create_app
+
+
+def _make_client(db_session: Session) -> TestClient:
+    """Create a test client with the DB session overridden."""
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: db_session
+    return TestClient(app)
+
+
+def _register_user(client: TestClient, username: str = "authuser", password: str = "securepass123") -> None:
+    """Register a user via the API so they have a real bcrypt hash."""
+    response = client.post(
+        "/auth/register",
+        json={"username": username, "password": password},
+    )
+    assert response.status_code == 201
+
+
+def _login_user(client: TestClient, username: str = "authuser", password: str = "securepass123") -> dict:
+    """Login and return the token response."""
+    response = client.post(
+        "/auth/login",
+        json={"username": username, "password": password},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+class TestAuthDependency:
+    """Tests for GET /auth/me (get_current_user dependency)."""
+
+    def test_me_with_valid_token(self, db_session: Session) -> None:
+        """Valid access token returns 200 and user data."""
+        client = _make_client(db_session)
+        _register_user(client)
+        tokens = _login_user(client)
+
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": f"Bearer {tokens['access_token']}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["username"] == "authuser"
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_me_without_auth_header(self, db_session: Session) -> None:
+        """Missing Authorization header returns 401."""
+        client = _make_client(db_session)
+
+        response = client.get("/auth/me")
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_me_with_invalid_token(self, db_session: Session) -> None:
+        """Invalid token returns 401."""
+        client = _make_client(db_session)
+
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": "Bearer totally-invalid-token"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid or expired token"
+
+    def test_me_with_expired_token(self, db_session: Session) -> None:
+        """Expired token returns 401."""
+        client = _make_client(db_session)
+        _register_user(client)
+
+        # Create a manually expired token
+        secret = os.environ["JWT_SECRET_KEY"]
+        expired_token = jwt.encode(
+            {
+                "sub": "1",
+                "username": "authuser",
+                "role": None,
+                "type": "access",
+                "iat": datetime.now(UTC) - timedelta(hours=2),
+                "exp": datetime.now(UTC) - timedelta(hours=1),
+            },
+            secret,
+            algorithm="HS256",
+        )
+
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": f"Bearer {expired_token}"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid or expired token"
+
+    def test_me_with_refresh_token(self, db_session: Session) -> None:
+        """Refresh token (wrong type) returns 401."""
+        client = _make_client(db_session)
+        _register_user(client)
+        tokens = _login_user(client)
+
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": f"Bearer {tokens['refresh_token']}"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid or expired token"


### PR DESCRIPTION
## Summary
- Adds `get_current_user()` FastAPI dependency that extracts Bearer JWT from Authorization header, validates it, and returns the User
- Adds `GET /auth/me` endpoint as a protected route demonstrating the dependency
- Returns 401 with `WWW-Authenticate: Bearer` header for missing, invalid, expired, or wrong-type tokens (RFC 6750)

## Changes
- `backend/src/the_lab/auth/dependencies.py` — new `get_current_user()` dependency (new file)
- `backend/src/the_lab/auth/router.py` — added `GET /auth/me` endpoint
- `backend/tests/test_auth_dependency.py` — 5 integration tests (new file)

## Test plan
- [x] Valid access token returns 200 with user data
- [x] Missing Authorization header returns 401 "Not authenticated"
- [x] Invalid token returns 401 "Invalid or expired token"
- [x] Expired token returns 401 "Invalid or expired token"
- [x] Refresh token (wrong type) returns 401
- [x] All existing auth tests pass (no regressions) — 22/22

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)